### PR TITLE
Potential fix for code scanning alert no. 184: Log entries created from user input

### DIFF
--- a/src/Melodee.Blazor/Controllers/Jellyfin/UsersController.cs
+++ b/src/Melodee.Blazor/Controllers/Jellyfin/UsersController.cs
@@ -31,6 +31,18 @@ public class UsersController(
     UserService userService,
     ILogger<UsersController> logger) : JellyfinControllerBase(etagRepository, serializer, configuration, configurationFactory, dbContextFactory, clock, loggerFactory)
 {
+    private static string SanitizeForLog(string value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty);
+    }
+
     /// <summary>
     /// Gets public users for the login screen. Finamp calls this to show available users.
     /// </summary>
@@ -53,7 +65,7 @@ public class UsersController(
         if (string.IsNullOrWhiteSpace(request.Username) || string.IsNullOrWhiteSpace(request.Pw))
         {
             logger.LogWarning("JellyfinAuthFailed UserName={UserName} RemoteIp={RemoteIp} Reason={Reason}",
-                request.Username ?? "[empty]", GetClientBinding(), "Missing credentials");
+                SanitizeForLog(request.Username ?? "[empty]"), GetClientBinding(), "Missing credentials");
             return JellyfinBadRequest("Username and password are required.");
         }
 
@@ -61,7 +73,7 @@ public class UsersController(
         if (!authenticateResult.IsSuccess || authenticateResult.Data == null)
         {
             logger.LogWarning("JellyfinAuthFailed UserName={UserName} RemoteIp={RemoteIp} Reason={Reason}",
-                request.Username, GetClientBinding(), "Invalid credentials");
+                SanitizeForLog(request.Username), GetClientBinding(), "Invalid credentials");
             return JellyfinUnauthorized("Invalid username or password.");
         }
 
@@ -69,7 +81,7 @@ public class UsersController(
         if (user.IsLocked)
         {
             logger.LogWarning("JellyfinAuthFailed UserName={UserName} RemoteIp={RemoteIp} Reason={Reason}",
-                request.Username, GetClientBinding(), "User locked");
+                SanitizeForLog(request.Username), GetClientBinding(), "User locked");
             return JellyfinForbidden("User account is locked.");
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/melodee-project/melodee/security/code-scanning/184](https://github.com/melodee-project/melodee/security/code-scanning/184)

In general, to fix log-forging issues, sanitize user-provided values before logging by removing or neutralizing characters that can break log structure (e.g., `\r`, `\n`) or that might be interpreted specially in the log rendering context. For plain text logs, stripping or replacing newline characters is usually sufficient; the message template itself already clearly marks user input as a field.

For this specific code, we should avoid logging `request.Username` directly and instead log a sanitized version. A simple, non-invasive fix is to normalize/strip newlines from the username before passing it to the logger. To avoid repeating logic, define a small private helper method inside `UsersController` (since we are allowed to add methods within the snippet’s file) that takes a string and returns a sanitized version with `\r` and `\n` removed. Then, use this helper in all three log statements that log the username:

- Line 55–56 (missing credentials case) already uses `request.Username ?? "[empty]"`; we should wrap that with the sanitizer.
- Line 63–64 (invalid credentials) logs `request.Username` directly; change it to the sanitized version.
- Line 71–72 (user locked) is the one CodeQL highlighted; change it to use the sanitized username as well.

We don’t need new external dependencies; a simple `Replace` chain is enough. The helper can be placed near the bottom of the controller class. No changes to imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
