### PR TITLE
ci: add github action to publish a docker image for each new release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,141 @@
+name: Docker Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+
+    outputs:
+      image: ${{ steps.image.outputs.name }}
+      labels: ${{ steps.meta.outputs.labels }}
+      json: ${{ steps.meta.outputs.json }}
+
+    steps:
+      - name: Define image name
+        id: image
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=sha,prefix=sha-,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+  build:
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            platform-id: linux-amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            platform-id: linux-arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          labels: ${{ needs.prepare.outputs.labels }}
+          outputs: type=image,name=${{ needs.prepare.outputs.image }},name-canonical=true,push-by-digest=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform-id }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform-id }}
+
+      - name: Export image digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform-id }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-platform manifest
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ needs.prepare.outputs.json }}
+          IMAGE_NAME: ${{ needs.prepare.outputs.image }}
+        run: |
+          cd /tmp/digests
+          # Build the list of digest references
+          digest_refs=""
+          for digest in *; do
+            digest_refs="$digest_refs $IMAGE_NAME@sha256:$digest"
+          done
+          # Create the manifest
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $digest_refs
+
+      - name: Inspect published image
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ needs.prepare.outputs.json }}
+        run: |
+          docker buildx imagetools inspect "$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ See: [`.github/workflows/`](./.github/workflows/)
 - [`dotnet.yml`](./.github/workflows/dotnet.yml): Main .NET build and test pipeline.
 - [`codeql.yml`](./.github/workflows/codeql.yml): Security scanning.
 - [`localization.yml`](./.github/workflows/localization.yml): Localization checks.
+- [`docker-publish.yml`](./.github/workflows/docker-publish.yml): Builds and publishes multi-arch container images to GHCR on every published release.
 
 ### Usage Guidelines for Agents
 1. **Context awareness**: Before generating code, always check [`.github/instructions/`](./.github/instructions/) for relevant guidelines. For example, if editing a Blazor component, consult [`blazor.instructions.md`](./.github/instructions/blazor.instructions.md).


### PR DESCRIPTION
Fixes #64 

Tested by running the action on my fork and then installing image in my k8s cluster, you should be able to see the build logs etc here: https://github.com/Maistho/melodee/actions/runs/23720015365

The built package here: https://github.com/Maistho/melodee/pkgs/container/melodee

Just built some bogus releases (1.2.3, then 1.2.4 and 1.2.5 to test)

I'm not sure how you would want to update the documentation, I guess in the future it would make sense to update the compose file that people are recommended to just link against that image instead of having to build the image themselves.