### PR TITLE
[codex] Run dependency review only for pull requests

### DIFF
--- a/.github/workflows/sca-container-scan.yml
+++ b/.github/workflows/sca-container-scan.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Vulnerability Scan (SCA)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary

Restrict the Dependency Review job in the security scanning workflow to pull request events.

## Root Cause

The `actions/dependency-review-action@v4` step failed on the post-merge `push` workflow because push events do not provide the base/head refs the action requires unless they are configured explicitly. The workflow already has separate NuGet and container vulnerability scans for `main` pushes, and both passed in the failing run.

## Validation

- `git diff --check`
- Inspected failing run `25227874889` with `gh run view --log-failed`

## Impact

PRs still run dependency review. Pushes to `main` skip that PR-specific job and continue running NuGet and container vulnerability scans.